### PR TITLE
Allow context menu pasting to fire change event

### DIFF
--- a/js/twemoji-picker.js
+++ b/js/twemoji-picker.js
@@ -1003,7 +1003,7 @@
         _initEvents : function() {
             var self = this;
 
-            this.$textarea.on('keyup', function() {
+            this.$textarea.on('input', function() {
                 self.copyTextArea($(this).html());
             });
 


### PR DESCRIPTION
When pasting with the context menu (right click) the textfield was not updating correctly. The input event catches this and updates everytime the content changes, no matter the input method.